### PR TITLE
Canvas: Fix touchscreen navigation

### DIFF
--- a/src/canvas/canvas.cpp
+++ b/src/canvas/canvas.cpp
@@ -287,7 +287,13 @@ void Canvas::drag_gesture_begin_cb(Gdk::EventSequence *seq)
     }
     else {
         m_gesture_drag_center_orig = m_center;
-        m_gesture_drag->set_state(Gtk::EventSequenceState::CLAIMED);
+        const auto source = m_gesture_drag->get_current_event_device()->get_source();
+        if (source == Gdk::InputSource::TOUCHSCREEN) {
+            m_gesture_drag->set_state(Gtk::EventSequenceState::NONE);
+        }
+        else {
+            m_gesture_drag->set_state(Gtk::EventSequenceState::CLAIMED);
+        }
     }
 }
 


### PR DESCRIPTION
### Scope

- Pan viewport by dragging with one finger (existing behaviour)
- Zoom viewport by pinching with two fingers (didn't work before)
- Rotate viewport by rotating with two fingers (didn't work before)

### Out of scope

- Touchscreen gestures currently still don't feel "immediate", i.e. like manipulating an actual physical object. In order to achieve this, the touch positions must stay fixed relative to the model during the gestures. In the current implementation, there's some kind of scaling factor dependent on the canvas size. On my machine, a canvas size of 750x750 feels about right; moving a single point will lag behind the actual finger positions on smaller canvasses and leap ahead on larger canvasses. Zooming and rotating also feels the most natural at this canvas size.
- Right now it is not possible to interact with the model using a touchscreen. Selecting entities by tapping them is a no-op, moving them by dragging also doesn't work, right-click actions are physically impossible.
- This has only been tested with finger touches. I couldn't test stylus support yet because I haven't been able to find my stylus.
- Ctrl / Shift modifiers to limit motion to zoom-only or rotate-only doesn't work due to the way it's initialised. Right now, the implicit `click` event at the start of a (touchpad) gesture is used to set the modifier mode, but no such event is generated when using a touchscreen.