### PR TITLE
Canvas: Increase maximum camera distance to a reasonable value

### DIFF
--- a/src/canvas/canvas.cpp
+++ b/src/canvas/canvas.cpp
@@ -707,7 +707,7 @@ bool Canvas::on_render(const Glib::RefPtr<Gdk::GLContext> &context)
         m_viewmat = glm::lookAt(cam_pos, m_center, glm::vec3(0, 0, std::abs(m_cam_elevation) < 90 ? 1 : -1));
 
         float cam_dist_min = 1;
-        float cam_dist_max = 500;
+        float cam_dist_max = 500000;
 
 
         float m = tan(0.5 * glm::radians(m_cam_fov)) / m_dev_height * m_cam_distance;


### PR DESCRIPTION
Fixes #22.

### Scope

- Increases maximum camera distance to 500.000 workspace units / 500 metres, which should be enough even for architectural work. If a larger distance is required, the workspace unit could be redefined to 1 m instead of 1 mm.

### Out of scope

- The unintended behaviour still exists, it just occurs at zoom levels that are three orders of magnitude larger than before.
- Ideally, the zoom factor should be clamped to a value range that doesn't exceed the maximum camera distance at all. This is not implemented yet.
- In itself, the maximum camera distance is a performance optimisation that should prevent entities from getting rendered that are too far away from the camera to be noticeable. This doesn't really apply to CAD software though because the model is finite, but always expected to be fully visible. The ideal solution would involve a fixed camera distance and a model that scales according to the zoom factor.
- I am not familiar with the math behind the camera projections, so I can not tell whether the increased maximum distance has some unintended side effects.