### PR TITLE
Fix typos

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -35,7 +35,7 @@ See [the CI configuration](../.github/workflows/all.yml) for the exact package n
 
 > [!IMPORTANT]
 > Dune 3D is currently still alpha software undergoing rapid development, so please don't package it for
-> your favourite distro yet. Users have expecations regarding stability and completeness towards packaged
+> your favourite distro yet. Users have expectations regarding stability and completeness towards packaged
 > software that Dune 3D doesn't meet yet. Also having built it from source makes it easier to get the
 > latest bugfixes and simplifies debugging.
 

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -1297,7 +1297,7 @@ bool Editor::handle_action_key(Glib::RefPtr<Gtk::EventControllerKey> controller,
 
             return true;
         }
-        else if (connections_matched.size() > 1 || in_tool_actions_matched.size() > 1) { // still ambigous
+        else if (connections_matched.size() > 1 || in_tool_actions_matched.size() > 1) { // still ambiguous
             std::list<std::pair<std::string, KeySequence>> conflicts;
             bool have_conflict = false;
             for (const auto &[conn, it] : connections_matched) {


### PR DESCRIPTION
Found via `codespell -q 3 -S "./3rd_party" -L enew,filetest,oce`