### PR TITLE
update actions/checkout in GitHub Actions workflows to v4

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -18,7 +18,7 @@ jobs:
   stylecheck:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install preliminary dependencies
       run: sudo apt-get update -y && sudo apt-get install curl gnupg apt-transport-https -y
     - name: Add clang 11.0 to apt sources
@@ -50,7 +50,7 @@ jobs:
     container: ${{ matrix.os.container }}
     needs: stylecheck
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: generate locales
       run: |
         apt-get update
@@ -74,7 +74,7 @@ jobs:
     container: archlinux:base-devel
     needs: stylecheck
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install updates
       run: pacman -Syu --noconfirm
     - name: Install dependencies
@@ -95,7 +95,7 @@ jobs:
     container: archlinux:base-devel
     needs: stylecheck
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install updates
       run: pacman -Syu --noconfirm
     - name: Install dependencies
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: stylecheck
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: nixbuild/nix-quick-install-action@v26
     - name: Build
       run: nix build .

--- a/.github/workflows/win32.yml
+++ b/.github/workflows/win32.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Check tag
       if: startsWith(github.ref, 'refs/tags/')
       run: echo "Building tag ${{ github.ref }}"
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: msys2/setup-msys2@v2
       with:
         update: true


### PR DESCRIPTION
This updates [actions/checkout](https://github.com/actions/checkout) to v4, it's current version.

Changelog:

> ## v4.1.0
> - Add support for partial checkout filters
>
> ## v4.0.0
> - Support fetching without the --progress option
> - Update to node20