### PR TITLE
Use system's stdlibc++, use macos v13 github action runner

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - name: Check tag
       if: startsWith(github.ref, 'refs/tags/')

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -3,8 +3,6 @@
 llvm_prefix="$(brew --prefix llvm)"
 export CC="$llvm_prefix/bin/clang"
 export CXX="$llvm_prefix/bin/clang++"
-export PATH="$llvm_prefix/bin:$PATH"
-export LDFLAGS="-L$llvm_prefix/lib/c++ -Wl,-rpath,$llvm_prefix/lib/c++"
 
 meson setup build
 meson compile -C build


### PR DESCRIPTION
I noticed that when linking with llvm's libc++, the system's libc++ was still included, probably linked to other libraries that we depend on?

It caused crashes, so I rolled back to using the system's libc++, and "upped" the github action image to macos-13.

We still have to compile using llvm from homebrew, bacause the clang from macos chokes on `std::format` and the "automatic constructor" stuff (not sure what it's called).

However, compiling using homebrew llvm, and linking to macos's libc++ (libSystem?) works, but only on macos 13 and up.

I guess this is the best solution for now.