### PR TITLE
Fix typo in MacOS part building.md

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -126,7 +126,7 @@ Follow the instructions, now you should be able to install the remaining depende
 
 ```
 brew install \
-	python@3
+	python@3 \
 	llvm \
 	eigen \
 	opencascade \

--- a/doc/building.md
+++ b/doc/building.md
@@ -149,3 +149,5 @@ brew install --HEAD meson
 Now you can build the project using the `./scripts/build_macos.sh` script.
 
 You should now have the `dune3d` executable in the `build/` folder.
+
+**Note**: Building on macOS is still experimental. You might find workarounds for building/linking issues in this project's [issues](https://github.com/dune3d/dune3d/issues). Also be aware that [selection in macOS is broken for now](https://github.com/dune3d/dune3d/pull/45#issuecomment-1877942473).


### PR DESCRIPTION
``` 
brew install \
        python@3 \ <--- Forgot the antislash here
        llvm \
        eigen \
        opencascade \
        pkg-config \
        gtk4 \
        gtkmm4 \
        glm \
        range-v3 \
        mimalloc \
        pygobject3 \
        librsvg
```