### PR TITLE
preferences: Add macOS keybindings

### DIFF
--- a/merge_gresource.py
+++ b/merge_gresource.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+from __future__ import print_function
+import sys
+import os
+import xml.etree.ElementTree as ET
+
+base_file, *patch_files, platform, outfile = sys.argv[1:]
+base_xml = ET.parse(base_file).getroot()
+
+for file in patch_files:
+  file_name = os.path.splitext(file)[0]
+  if file_name.endswith(platform):
+    for patched_file in ET.parse(file).getroot().find("gresource").iter("file"):
+      target = patched_file.get("alias")
+      source = base_xml.find(f'.//file[.="{target}"]')
+      source.set("alias", target)
+      source.text = patched_file.text
+
+ET.ElementTree(base_xml).write(outfile)

--- a/meson.build
+++ b/meson.build
@@ -235,10 +235,17 @@ version_gen_cpp = custom_target(
 )
 src += version_gen_cpp
 
+resource_xml = custom_target(
+    'dune3d.gresource.xml',
+    output : 'dune3d.gresource.xml',
+    input : ['merge_gresource.py', 'src/dune3d.gresource.xml', 'src/dune3d.gresource.darwin.xml'],
+    command : [prog_python, '@INPUT@', target_machine.system(), '@OUTPUT@'],
+)
+
 gnome = import('gnome')
 resources = gnome.compile_resources(
   'resources',
-  'src/dune3d.gresource.xml',
+  resource_xml,
   dependencies: [icon_texture],
   c_name: 'dune3d_resources',
   source_dir: 'src'

--- a/src/action/action.cpp
+++ b/src/action/action.cpp
@@ -19,6 +19,13 @@ std::string key_sequence_item_to_string(const KeySequenceItem &it)
     if ((int)(it.mod & Gdk::ModifierType::ALT_MASK)) {
         txt += "Alt+";
     }
+    if ((int)(it.mod & Gdk::ModifierType::META_MASK)) {
+#ifdef __APPLE__
+        txt += "⌘+";
+#else
+        txt += "Meta+";
+#endif
+    }
     txt += keyname;
     return txt;
 }

--- a/src/dune3d.gresource.darwin.xml
+++ b/src/dune3d.gresource.darwin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/dune3d/dune3d">
+    <file alias="preferences/keys_default.json">preferences/keys_default.darwin.json</file>
+  </gresource>
+</gresources>

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -1670,7 +1670,8 @@ bool Editor::handle_action_key(Glib::RefPtr<Gtk::EventControllerKey> controller,
     if (ev->is_modifier())
         return false;
     state &= ~ev->get_consumed_modifiers();
-    state &= (Gdk::ModifierType::SHIFT_MASK | Gdk::ModifierType::CONTROL_MASK | Gdk::ModifierType::ALT_MASK);
+    state &= (Gdk::ModifierType::SHIFT_MASK | Gdk::ModifierType::CONTROL_MASK | Gdk::ModifierType::ALT_MASK
+              | Gdk::ModifierType::META_MASK);
     if (keyval == GDK_KEY_Escape) {
         if (!m_core.tool_is_active()) {
             get_canvas().set_selection_mode(SelectionMode::HOVER);

--- a/src/preferences/keys_default.darwin.json
+++ b/src/preferences/keys_default.darwin.json
@@ -1,0 +1,826 @@
+[
+    {
+        "action": "SAVE",
+        "keys": [
+            [
+                {
+                    "key": "s",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "SAVE_AS",
+        "keys": [
+            [
+                {
+                    "key": "S",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "UNDO",
+        "keys": [
+            [
+                {
+                    "key": "z",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "REDO",
+        "keys": [
+            [
+                {
+                    "key": "y",
+                    "mod": 268435456
+                }
+            ],
+            [
+                {
+                    "key": "Z",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "POPOVER",
+        "keys": [
+            [
+                {
+                    "key": "space",
+                    "mod": 0
+                }
+            ]
+        ]
+    },
+    {
+        "action": "CLOSE_DOCUMENT",
+        "keys": [
+            [
+                {
+                    "key": "w",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "OPEN_DOCUMENT",
+        "keys": [
+            [
+                {
+                    "key": "o",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "NEW_DOCUMENT",
+        "keys": [
+            [
+                {
+                    "key": "n",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "PREVIOUS_GROUP",
+        "keys": [
+            [
+                {
+                    "key": "Page_Up",
+                    "mod": 0
+                }
+            ]
+        ]
+    },
+    {
+        "action": "NEXT_GROUP",
+        "keys": [
+            [
+                {
+                    "key": "Page_Down",
+                    "mod": 0
+                }
+            ]
+        ]
+    },
+    {
+        "action": "PREFERENCES",
+        "keys": [
+            [
+                {
+                    "key": "comma",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "TOGGLE_SOLID_MODEL",
+        "keys": [
+            [
+                {
+                    "key": "s",
+                    "mod": 8
+                }
+            ]
+        ]
+    },
+    {
+        "action": "VIEW_ALL",
+        "keys": [
+            [
+                {
+                    "key": "Home",
+                    "mod": 0
+                }
+            ]
+        ]
+    },
+    {
+        "action": "VIEW_TOGGLE_PERSP_ORTHO",
+        "keys": [
+            [
+                {
+                    "key": "p",
+                    "mod": 0
+                }
+            ]
+        ]
+    },
+    {
+        "action": "VIEW_RESET_TILT",
+        "keys": [
+            [
+                {
+                    "key": "t",
+                    "mod": 8
+                }
+            ]
+        ]
+    },
+    {
+        "action": "DELETE_CURRENT_GROUP",
+        "keys": [
+            [
+                {
+                    "key": "BackSpace",
+                    "mod": 1
+                }
+            ]
+        ]
+    },
+    {
+        "action": "MOVE_GROUP_UP",
+        "keys": [
+            [
+                {
+                    "key": "Page_Up",
+                    "mod": 1
+                }
+            ]
+        ]
+    },
+    {
+        "action": "MOVE_GROUP_DOWN",
+        "keys": [
+            [
+                {
+                    "key": "Page_Down",
+                    "mod": 1
+                }
+            ]
+        ]
+    },
+    {
+        "action": "MOVE_GROUP_TO_END_OF_BODY",
+        "keys": [
+            [
+                {
+                    "key": "End",
+                    "mod": 1
+                }
+            ]
+        ]
+    },
+    {
+        "action": "CREATE_GROUP_SKETCH",
+        "keys": [
+            [
+                {
+                    "key": "k",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "CREATE_GROUP_EXTRUDE",
+        "keys": [
+            [
+                {
+                    "key": "e",
+                    "mod": 268435456
+                }
+            ]
+        ]
+    },
+    {
+        "action": "TOGGLE_WORKPLANE",
+        "keys": [
+            [
+                {
+                    "key": "w",
+                    "mod": 8
+                }
+            ]
+        ]
+    },
+    {
+        "action": "ALIGN_VIEW_TO_CURRENT_WORKPLANE",
+        "keys": [
+            [
+                {
+                    "key": "period",
+                    "mod": 0
+                }
+            ]
+        ]
+    },
+    {
+        "action": "CENTER_VIEW_TO_CURRENT_WORKPLANE",
+        "keys": [
+            [
+                {
+                    "key": "comma",
+                    "mod": 0
+                }
+            ]
+        ]
+    },
+    {
+        "action": "CLIPPING_PLANE_WINDOW",
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 8
+                }
+            ]
+        ]
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "3",
+                    "mod": 0
+                }
+            ],
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "L",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DRAW_LINE_3D"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "f",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DRAW_LINE_2D"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "a",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DRAW_ARC_2D"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "c",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DRAW_CIRCLE_2D"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "w",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DRAW_WORKPLANE"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "s",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DRAW_CONTOUR"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "BackSpace",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DELETE"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "m",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "MOVE"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "c",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_COINCIDENT"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "h",
+                    "mod": 0
+                }
+            ],
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "a",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_HORIZONTAL_AUTO"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "v",
+                    "mod": 0
+                }
+            ],
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "a",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_VERTICAL_AUTO"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "h",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_HORIZONTAL"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "v",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_VERTICAL"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "d",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_DISTANCE"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "h",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_DISTANCE_HORIZONTAL"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "v",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_DISTANCE_VERTICAL"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "s",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_SAME_ORIENTATION"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "w",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_WORKPLANE_NORMAL"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "p",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_PARALLEL"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "m",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_MIDPOINT"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "q",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_EQUAL_LENGTH"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "q",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_EQUAL_RADIUS"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "r",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_RADIUS"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "d",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_DIAMETER"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "o",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_PERPENDICULAR"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "g",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_ANGLE"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "c",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_POINT_IN_PLANE"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "c",
+                    "mod": 0
+                },
+                {
+                    "key": "k",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "CONSTRAIN_LOCK_ROTATION"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "Return",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "ENTER_DATUM"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "g",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "TOGGLE_CONSTRUCTION"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "w",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "SET_WORKPLANE"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "W",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "UNSET_WORKPLANE"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "t",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DRAW_POINT_2D"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "x",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DRAW_REGULAR_POLYGON"
+    },
+    {
+        "keys": [
+            [
+                {
+                    "key": "d",
+                    "mod": 0
+                },
+                {
+                    "key": "r",
+                    "mod": 0
+                }
+            ]
+        ],
+        "tool": "DRAW_RECTANGLE"
+    }
+]

--- a/src/widgets/capture_dialog.cpp
+++ b/src/widgets/capture_dialog.cpp
@@ -43,7 +43,7 @@ CaptureDialog::CaptureDialog(Gtk::Window *parent)
                         return false;
                     state &= ~ev->get_consumed_modifiers();
                     state &= (Gdk::ModifierType::SHIFT_MASK | Gdk::ModifierType::CONTROL_MASK
-                              | Gdk::ModifierType::ALT_MASK);
+                              | Gdk::ModifierType::ALT_MASK | Gdk::ModifierType::META_MASK);
                     m_keys.emplace_back(keyval, state);
                     update();
                     return true;


### PR DESCRIPTION
Fixes #58

### Scope

- Add support for assigning ⌘ modifier to keyboard shortcuts
- Enable platform-specific `gresource.xml` files that are merged with the default `gresource.xml`
- Introduce macOS-specific default keybindings that adhere to platform conventions