### PR TITLE
preferences: Remap macOS keys

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -196,6 +196,7 @@ src = files(
   'src/util/msd.cpp',
   'src/util/msd_animator.cpp',
   'src/util/exception_util.cpp',
+  'src/util/key_util.cpp',
 )
 
 prog_python = find_program('python3')

--- a/src/action/action.cpp
+++ b/src/action/action.cpp
@@ -6,34 +6,6 @@
 
 namespace dune3d {
 
-std::string key_sequence_item_to_string(const KeySequenceItem &it)
-{
-    std::string txt;
-    std::string keyname(gdk_keyval_name(it.key));
-    if ((int)(it.mod & Gdk::ModifierType::CONTROL_MASK)) {
-        txt += "Ctrl+";
-    }
-    if ((int)(it.mod & Gdk::ModifierType::SHIFT_MASK)) {
-        txt += "Shift+";
-    }
-    if ((int)(it.mod & Gdk::ModifierType::ALT_MASK)) {
-        txt += "Alt+";
-    }
-    txt += keyname;
-    return txt;
-}
-
-std::string key_sequence_to_string(const KeySequence &keys)
-{
-    std::string txt;
-    for (const auto &it : keys) {
-        txt += key_sequence_item_to_string(it);
-        txt += " ";
-    }
-    rtrim(txt);
-    return txt;
-}
-
 static std::string keyval_to_string(unsigned int kv)
 {
     switch (kv) {
@@ -56,12 +28,52 @@ static std::string keyval_to_string(unsigned int kv)
     case GDK_KEY_greater:
         return ">";
     case GDK_KEY_BackSpace:
+#ifdef __APPLE__
+        return "Delete";
+    case GDK_KEY_Delete:
+#endif
         return "⌫";
     case GDK_KEY_Escape:
         return "Esc";
     default:
         return gdk_keyval_name(kv);
     }
+}
+
+std::string key_sequence_item_to_string(const KeySequenceItem &it)
+{
+    std::string txt;
+    std::string keyname = keyval_to_string(it.key);
+    if ((int)(it.mod & Gdk::ModifierType::CONTROL_MASK)) {
+#ifdef __APPLE__
+        txt += "⌘+";
+#else
+        txt += "Ctrl+";
+#endif
+    }
+    if ((int)(it.mod & Gdk::ModifierType::SHIFT_MASK)) {
+        txt += "Shift+";
+    }
+    if ((int)(it.mod & Gdk::ModifierType::ALT_MASK)) {
+#ifdef __APPLE__
+        txt += "Ctrl+";
+#else
+        txt += "Alt+";
+#endif
+    }
+    txt += keyname;
+    return txt;
+}
+
+std::string key_sequence_to_string(const KeySequence &keys)
+{
+    std::string txt;
+    for (const auto &it : keys) {
+        txt += key_sequence_item_to_string(it);
+        txt += " ";
+    }
+    rtrim(txt);
+    return txt;
 }
 
 std::string key_sequence_to_string_short(const KeySequence &keys)

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -21,6 +21,7 @@
 #include "logger/logger.hpp"
 #include "document/constraint/constraint.hpp"
 #include "util/fs_util.hpp"
+#include "util/key_util.hpp"
 #include "util/util.hpp"
 #include "selection_editor.hpp"
 #include "preferences/color_presets.hpp"
@@ -1670,6 +1671,7 @@ bool Editor::handle_action_key(Glib::RefPtr<Gtk::EventControllerKey> controller,
     if (ev->is_modifier())
         return false;
     state &= ~ev->get_consumed_modifiers();
+    remap_keys(keyval, state);
     state &= (Gdk::ModifierType::SHIFT_MASK | Gdk::ModifierType::CONTROL_MASK | Gdk::ModifierType::ALT_MASK);
     if (keyval == GDK_KEY_Escape) {
         if (!m_core.tool_is_active()) {

--- a/src/util/key_util.cpp
+++ b/src/util/key_util.cpp
@@ -1,0 +1,24 @@
+#include "key_util.hpp"
+
+namespace dune3d {
+
+void remap_keys(guint &keyval, Gdk::ModifierType &state)
+{
+#ifdef __APPLE__
+    state &= (Gdk::ModifierType)GDK_MODIFIER_MASK;
+    if ((int)(state & Gdk::ModifierType::CONTROL_MASK)) {
+        state &= ~Gdk::ModifierType::CONTROL_MASK;
+        state |= Gdk::ModifierType::ALT_MASK;
+    }
+    if ((int)(state & Gdk::ModifierType::META_MASK)) {
+        state &= ~Gdk::ModifierType::META_MASK;
+        state |= Gdk::ModifierType::CONTROL_MASK;
+    }
+    if (keyval == GDK_KEY_BackSpace)
+        keyval = GDK_KEY_Delete;
+    else if (keyval == GDK_KEY_Delete)
+        keyval = GDK_KEY_BackSpace;
+#endif
+}
+
+} // namespace dune3d

--- a/src/util/key_util.hpp
+++ b/src/util/key_util.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include <gtkmm.h>
+
+namespace dune3d {
+void remap_keys(guint &keyval, Gdk::ModifierType &state);
+} // namespace dune3d

--- a/src/widgets/capture_dialog.cpp
+++ b/src/widgets/capture_dialog.cpp
@@ -1,4 +1,5 @@
 #include "capture_dialog.hpp"
+#include "util/key_util.hpp"
 #include <iostream>
 
 namespace dune3d {
@@ -42,6 +43,7 @@ CaptureDialog::CaptureDialog(Gtk::Window *parent)
                     if (ev->is_modifier())
                         return false;
                     state &= ~ev->get_consumed_modifiers();
+                    remap_keys(keyval, state);
                     state &= (Gdk::ModifierType::SHIFT_MASK | Gdk::ModifierType::CONTROL_MASK
                               | Gdk::ModifierType::ALT_MASK);
                     m_keys.emplace_back(keyval, state);


### PR DESCRIPTION
This PR will remap the PC-based keybindings to align with platform conventions on macOS. `Cmd` will be used instead of `Ctrl`, the non-existent `Alt` key will be replaced with (Mac) `Ctrl`, `Backspace` and `Delete` will be swapped. The remapping allows for a platform-independent default keybinding and makes custom keybindings portable between platforms.

Fixes #58.
Supersedes #59 .

### Scope
- Remap key modifier codes for Cmd (Mac) to Ctrl (PC) and Ctrl (Mac) to Alt (PC) on Mac
- Swap internal key codes for Backspace and Delete on Mac
- Revert the Mac key remapping for display purposes
- Make `key_sequence_item_to_string` use `keyval_to_string` for pretty-printing keys as well

### Out of scope
- Using `Option` as a modifier might not work for non-character keys because it is not configured as a valid modifier key.