### PR TITLE
Add macOS support to Nix Flake

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -113,6 +113,19 @@ jobs:
     needs: stylecheck
     steps:
     - uses: actions/checkout@v4
-    - uses: nixbuild/nix-quick-install-action@v26
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - name: Build
+      run: nix build .
+  
+  build-nix-macos:
+    strategy:
+      fail-fast: false
+    runs-on: macos-13
+    needs: stylecheck
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Build
       run: nix build .

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ wix/version.wxi
 compile_commands.json
 *.kate-swp
 perf.data*
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,30 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703637592,
-        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
+        "lastModified": 1707546158,
+        "narHash": "sha256-nYYJTpzfPMDxI8mzhQsYjIUX+grorqjKEU9Np6Xwy/0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
+        "rev": "d934204a0f8d9198e1e4515dd6fec76a139c87f0",
         "type": "github"
       },
       "original": {
@@ -18,7 +36,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,40 +3,61 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs }: let
-    system = "x86_64-linux";
-    pkgs = import nixpkgs {
-      inherit system;
-    };
-  in {
-    packages."${system}".default = let
-      stdenv = pkgs.gcc13Stdenv;
-      pythonEnv = pkgs.python3.withPackages(p: [ p.pygobject3 ]);
-    in stdenv.mkDerivation rec {
-      name = "dune3d";
-      src = ./.;
-      nativeBuildInputs = [
-        pkgs.meson
-        pkgs.ninja
-        pkgs.cmake
-        pkgs.librsvg
-        pkgs.gobject-introspection
-        pkgs.pkg-config
-        pkgs.wrapGAppsHook
-        pythonEnv
-      ];
-      buildInputs = [
-        pkgs.eigen
-        pkgs.glm
-        pkgs.gtkmm4
-        pkgs.libepoxy
-        pkgs.libspnav
-        pkgs.libuuid
-        pkgs.opencascade-occt
-      ];
-      env.CASROOT = pkgs.opencascade-occt;
-    };
-  };
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        stdenv = if pkgs.stdenv.hostPlatform.isDarwin then pkgs.llvmPackages_17.stdenv
+                  else pkgs.gcc13Stdenv;
+        pythonEnv = pkgs.python3.withPackages (p: [ p.pygobject3 ]);
+      in
+      {
+        packages = rec {
+          dune3d =
+            stdenv.mkDerivation {
+              name = "dune3d";
+              src = builtins.path { path = ./.; name = "dune3d-source"; };
+
+              nativeBuildInputs = [
+                pkgs.meson
+                pkgs.ninja
+                pkgs.cmake
+                pkgs.librsvg
+                pkgs.gobject-introspection
+                pkgs.pkg-config
+                pkgs.wrapGAppsHook
+                pythonEnv
+              ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+                pkgs.desktopToDarwinBundle
+              ];
+
+              buildInputs = [
+                pkgs.eigen
+                pkgs.glm
+                pkgs.gtkmm4
+                pkgs.libepoxy
+                pkgs.libspnav
+                (if pkgs.hostPlatform.isLinux then pkgs.libuuid else pkgs.libossp_uuid)
+                pkgs.opencascade-occt
+              ];
+
+              meta = with pkgs.lib; {
+                description = "Parametric 3D CAD";
+                homepage = "https://dune3d.org";
+                license = licenses.gpl3Only;
+                platforms = platforms.unix;
+                mainProgram = "dune3d";
+              };
+            };
+          default = dune3d;
+        };
+        apps = rec {
+          dune3d = flake-utils.lib.mkApp { drv = self.packages.${system}.dune3d; };
+          default = dune3d;
+        };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -10,9 +10,9 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        inherit (pkgs) lib;
         stdenv = if pkgs.stdenv.hostPlatform.isDarwin then pkgs.llvmPackages_17.stdenv
                   else pkgs.gcc13Stdenv;
-        pythonEnv = pkgs.python3.withPackages (p: [ p.pygobject3 ]);
       in
       {
         packages = rec {
@@ -29,8 +29,8 @@
                 pkgs.gobject-introspection
                 pkgs.pkg-config
                 pkgs.wrapGAppsHook
-                pythonEnv
-              ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+                (pkgs.python3.withPackages (p: [ p.pygobject3 ]))
+              ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
                 pkgs.desktopToDarwinBundle
               ];
 
@@ -40,20 +40,21 @@
                 pkgs.gtkmm4
                 pkgs.libepoxy
                 pkgs.libspnav
-                (if pkgs.hostPlatform.isLinux then pkgs.libuuid else pkgs.libossp_uuid)
+                (if stdenv.hostPlatform.isLinux then pkgs.libuuid else pkgs.libossp_uuid)
                 pkgs.opencascade-occt
               ];
 
-              meta = with pkgs.lib; {
+              meta = with lib; {
                 description = "Parametric 3D CAD";
                 homepage = "https://dune3d.org";
-                license = licenses.gpl3Only;
+                license = licenses.gpl3Plus;
                 platforms = platforms.unix;
                 mainProgram = "dune3d";
               };
             };
           default = dune3d;
         };
+
         apps = rec {
           dune3d = flake-utils.lib.mkApp { drv = self.packages.${system}.dune3d; };
           default = dune3d;

--- a/meson.build
+++ b/meson.build
@@ -19,9 +19,15 @@ glm = dependency('glm')
 opencascade = dependency('OpenCASCADE', method : 'cmake', required:target_machine.system() != 'darwin')
 if target_machine.system() == 'darwin'
   message('meson\'s framework handling on macos with the cmake method is broken, replacing')
-  brew_prefix_cmd = run_command('brew', '--prefix', check: true)
-  brew_prefix = brew_prefix_cmd.stdout().strip() + '/lib'
-  opencascade = declare_dependency(dependencies: opencascade.partial_dependency(compile_args: true, includes:true), link_args:['-Wl,-L' + brew_prefix, '-lTKSTEP', '-lTKernel', '-lTKXCAF', '-lTKXSBase', '-lTKBRep', '-lTKCDF', '-lTKXDESTEP', '-lTKLCAF', '-lTKMath', '-lTKMesh', '-lTKTopAlgo', '-lTKPrim', '-lTKBO', '-lTKShHealing', '-lTKG3d', '-lTKGeomBase', '-lTKHLR', '-lTKSTL', '-lTKFillet'])
+  opencascade_link_args = []
+  brew = find_program('brew', required : false)
+  if brew.found()
+    brew_prefix_cmd = run_command('brew', '--prefix', check: true)
+    brew_prefix = brew_prefix_cmd.stdout().strip() + '/lib'
+    opencascade_link_args += ['-Wl,-L' + brew_prefix]
+  endif
+  opencascade_link_args += ['-lTKSTEP', '-lTKernel', '-lTKXCAF', '-lTKXSBase', '-lTKBRep', '-lTKCDF', '-lTKXDESTEP', '-lTKLCAF', '-lTKMath', '-lTKMesh', '-lTKTopAlgo', '-lTKPrim', '-lTKBO', '-lTKShHealing', '-lTKG3d', '-lTKGeomBase', '-lTKHLR', '-lTKSTL', '-lTKFillet']
+  opencascade = declare_dependency(dependencies: opencascade.partial_dependency(compile_args: true, includes:true), link_args: opencascade_link_args)
 endif
 
 spnav = dependency('spnav', required: false)


### PR DESCRIPTION
- Adds support for macOS and non-`x86_64-linux` platforms to the nix flake
- `meson.build` changes to allow building without `brew`
    - Hopefully this hasn't broken the build however I don't have a mac with homebrew to test 😅 
- Adds metadata in preparation for submitting a package to nixpkgs

Test with `nix run github:emilytrau/dune3d/flake-macos`