### PR TITLE
Canvas: Disable MSAA on Mac to fix picking issues

### DIFF
--- a/src/canvas/canvas.cpp
+++ b/src/canvas/canvas.cpp
@@ -838,6 +838,9 @@ bool Canvas::on_render(const Glib::RefPtr<Gdk::GLContext> &context)
 
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
 
+#ifdef __APPLE__
+    glDisable(GL_MULTISAMPLE);
+#endif
     glClearColor(0, 0, 0, 0);
     glClearDepth(10);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);


### PR DESCRIPTION
Fixes #57.

### The issue

On macOS, rendering the pick buffer is subject to antialiasing artifacts, causing the rendered pick indices to be blended instead of just passed through. As a result, placing the mouse over an entity might not actually select it, but a different entity (or none at all) depending on the blended pick index.

### The fix

This PR will disable multisampling specifically on macOS and therefore ensure that the pick indices will be passed accurately. Note that the lack of MSAA does not appear to degrade rendering quality.