### PR TITLE
Rebuild glibmm on macOS as a work-around for broken bottle

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,5 +44,14 @@ jobs:
 
         # the stable meson version seems to crash with the cmake dependency
         brew install --HEAD meson
+
+        # glibmm's bottle appears to be broken and will currently result in the following error:
+        #
+        # ld: Undefined symbols:
+        #   Glib::DateTime::create_now_local(long long), referenced from:
+        #     dune3d::Dune3DApplication::UserConfig::load(std::__1::__fs::filesystem::path const&) in src_dune3d_application.cpp.o
+        #
+        # Rebuilding glibmm from source appears to work around the issue for now.
+        brew reinstall -s glibmm
     - name: Build
       run: bash scripts/build_macos.sh && otool -L build/dune3d


### PR DESCRIPTION
The binary build seems to be slightly different than the include files shipped in the pre-built bottle (binary package) and it will currently result in the following build error:

```
   ld: Undefined symbols:
     Glib::DateTime::create_now_local(long long), referenced from:
       dune3d::Dune3DApplication::UserConfig::load(std::__1::__fs::filesystem::path const&) in src_dune3d_application.cpp.o
```

Rebuilding glibmm from source appears to work around the issue for now.

See also #49 