### PR TITLE
Use stable Meson on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,9 +41,6 @@ jobs:
           pygobject3 \
           librsvg
 
-        # the stable meson version seems to crash with the cmake dependency
-        brew install --HEAD meson
-
         # glibmm's bottle appears to be broken and will currently result in the following error:
         #
         # ld: Undefined symbols:


### PR DESCRIPTION
It seems that using the development version of Meson is no longer required as of Meson 1.4.