### PR TITLE
Make Open Cascade a required dependency on all platforms

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ eigen = dependency('eigen3')
 glm = dependency('glm')
 
 
-opencascade = dependency('OpenCASCADE', method : 'cmake', required:target_machine.system() != 'darwin')
+opencascade = dependency('OpenCASCADE', method : 'cmake')
 if target_machine.system() == 'darwin'
   message('meson\'s framework handling on macos with the cmake method is broken, replacing')
   opencascade_link_args = []


### PR DESCRIPTION
The Open Cascade dependency is effectively required on all platforms, including macOS.

Before this commit, if CMake was missing on macOS, Open Cascade was not found. Although Meson printed a warning, the configuration step completed successfully, leading to a build error later in the process.