### PR TITLE
Make text in selection editor easier to understand

### DIFF
--- a/src/document/entity/entity.cpp
+++ b/src/document/entity/entity.cpp
@@ -43,6 +43,37 @@ std::string Entity::get_type_name() const
     return get_type_name(get_type());
 }
 
+std::string Entity::get_type_name_plural(Type type)
+{
+    switch (type) {
+    case Type::LINE_2D:
+        return "Lines in workplane";
+    case Type::LINE_3D:
+        return "Lines in 3D";
+    case Type::ARC_2D:
+        return "Arcs in workplane";
+    case Type::ARC_3D:
+        return "Arcs in 3D";
+    case Type::CIRCLE_2D:
+        return "Circles in workplane";
+    case Type::CIRCLE_3D:
+        return "Circles in 3D";
+    case Type::STEP:
+        return "STEP models";
+    case Type::WORKPLANE:
+        return "Workplanes";
+    case Type::POINT_2D:
+        return "Points in workplane";
+    default:
+        return "Entities";
+    }
+}
+
+std::string Entity::get_type_name_plural() const
+{
+    return get_type_name_plural(get_type());
+}
+
 Entity::Entity(const UUID &uu, const json &j)
     : m_uuid(uu), m_name(j.value("name", "")), m_construction(j.value("construction", false))
 {

--- a/src/document/entity/entity.cpp
+++ b/src/document/entity/entity.cpp
@@ -74,6 +74,16 @@ std::string Entity::get_type_name_plural() const
     return get_type_name_plural(get_type());
 }
 
+std::string Entity::get_type_name_for_n(Type type, std::size_t n)
+{
+    return n == 1 ? get_type_name(type) : get_type_name_plural(type);
+}
+
+std::string Entity::get_type_name_for_n(std::size_t n) const
+{
+    return get_type_name_for_n(get_type(), n);
+}
+
 Entity::Entity(const UUID &uu, const json &j)
     : m_uuid(uu), m_name(j.value("name", "")), m_construction(j.value("construction", false))
 {

--- a/src/document/entity/entity.hpp
+++ b/src/document/entity/entity.hpp
@@ -36,8 +36,10 @@ public:
     virtual Type get_type() const = 0;
     static std::string get_type_name(Type type);
     static std::string get_type_name_plural(Type type);
+    static std::string get_type_name_for_n(Type type, std::size_t n);
     std::string get_type_name() const;
     std::string get_type_name_plural() const;
+    std::string get_type_name_for_n(std::size_t n) const;
 
     template <typename... Args> bool of_type(Args &&...args) const
     {

--- a/src/document/entity/entity.hpp
+++ b/src/document/entity/entity.hpp
@@ -35,7 +35,9 @@ public:
     using Type = EntityType;
     virtual Type get_type() const = 0;
     static std::string get_type_name(Type type);
+    static std::string get_type_name_plural(Type type);
     std::string get_type_name() const;
+    std::string get_type_name_plural() const;
 
     template <typename... Args> bool of_type(Args &&...args) const
     {

--- a/src/editor/selection_editor.cpp
+++ b/src/editor/selection_editor.cpp
@@ -47,7 +47,8 @@ public:
         for (const auto &[type, count] : item_count) {
             std::string type_name;
             if (auto entity_type = std::get_if<Entity::Type>(&type)) {
-                type_name = Entity::get_type_name(*entity_type);
+                type_name =
+                        count == 1 ? Entity::get_type_name(*entity_type) : Entity::get_type_name_plural(*entity_type);
             }
             else if (auto constraint_type = std::get_if<Constraint::Type>(&type)) {
                 type_name = Constraint::get_type_name(*constraint_type);

--- a/src/editor/selection_editor.cpp
+++ b/src/editor/selection_editor.cpp
@@ -47,8 +47,7 @@ public:
         for (const auto &[type, count] : item_count) {
             std::string type_name;
             if (auto entity_type = std::get_if<Entity::Type>(&type)) {
-                type_name =
-                        count == 1 ? Entity::get_type_name(*entity_type) : Entity::get_type_name_plural(*entity_type);
+                type_name = Entity::get_type_name_for_n(*entity_type, count);
             }
             else if (auto constraint_type = std::get_if<Constraint::Type>(&type)) {
                 type_name = Constraint::get_type_name(*constraint_type);

--- a/src/editor/selection_editor.cpp
+++ b/src/editor/selection_editor.cpp
@@ -53,6 +53,7 @@ public:
             else if (auto constraint_type = std::get_if<Constraint::Type>(&type)) {
                 type_name = Constraint::get_type_name(*constraint_type);
             }
+            type_name += ":";
             {
                 auto la = Gtk::make_managed<Gtk::Label>(type_name);
                 la->set_xalign(1);


### PR DESCRIPTION
As a newbie it's quite difficult to comprehend what e.g. "Line in workplane 3" means (3 lines or line number 3?).
Therefore change the following:
1. Add a colon between the type name and the amount
2. Use the plural form if there are multiples of the same entity selected. (Don't use plural for constraints as there seem to be no good plural forms)