### PR TITLE
mac: fix closing of log window

### DIFF
--- a/src/dune3d_application.cpp
+++ b/src/dune3d_application.cpp
@@ -104,7 +104,8 @@ void Dune3DApplication::on_startup()
     m_log_dispatcher.set_handler([this](const auto &it) { m_log_window->get_view().push_log(it); });
     Logger::get().set_log_handler([this](const Logger::Item &it) { m_log_dispatcher.log(it); });
     property_active_window().signal_changed().connect([this] {
-        if (auto win = get_active_window())
+        auto win = get_active_window();
+        if (win && win != m_log_window->get_transient_for())
             m_log_window->set_transient_for(*win);
     });
 


### PR DESCRIPTION
### The issue

On macOS, the logger window can not be closed. Closing it will move it to the center of the screen and make it non-interactive, but it won't disappear.

### The cause

The active window changed signal gets triggered during closing the log window, which in turn calls `set_transient_for`. Evidently, calling it at this point in time disrupts the window close action and leaves it in an unexpected state.

### The fix

~~By moving the `set_transient_for` call to `show_log_window`, it is ensured that it never gets called while the log window is being closed.~~

`set_transient_for` will now only be called if the value changes. This ensures that it never happens while the log window is closing.