### PR TITLE
mac: fix broken selection on intel platform

### DIFF
--- a/src/canvas/canvas.cpp
+++ b/src/canvas/canvas.cpp
@@ -907,8 +907,9 @@ GLint Canvas::get_samples() const
 #ifndef __APPLE__
     return m_appearance.msaa;
 #else
-    // samples above 1 does not seem to work on macOS
-    return 1;
+    // multisampling does not seem to work on macOS
+    // setting the sampling factor to 0 will fall back to the non-multisampled behavior
+    return 0;
 #endif
 }
 


### PR DESCRIPTION
Fixes #172.

There seems to be a platform-specific difference in treatment of the MSAA sampling factor. On arm64-based Macs, setting it to `1` works as expected, but it breaks rendering to the pick buffer on Intel-based Macs. Setting it to `0` ensures compatibility with both platforms.