### PR TITLE
canvas: fix box selection release edge case

### DIFF
--- a/src/canvas/canvas.cpp
+++ b/src/canvas/canvas.cpp
@@ -238,11 +238,7 @@ void Canvas::setup_controllers()
             }
         });
         controller->signal_released().connect([this](int n_press, double x, double y) { handle_click_release(); });
-        controller->signal_cancel().connect([this](auto seq) {
-            m_long_click_connection.disconnect();
-            m_dragging = false;
-            m_inhibit_drag_selection = false;
-        });
+        controller->signal_cancel().connect([this](auto seq) { handle_click_release(); });
         add_controller(controller);
     }
 


### PR DESCRIPTION
Fixes #175.

Previously, in the rare event that the canvas `GestureClick` controller received a `signal_cancelled`, it would just do some minor cleanup without resetting/removing the box selection. These changes will ensure that a `signal_cancel` event is treated the same way as `signal_released`.

Note: I haven't been able to trigger `signal_cancelled` reliably - it only seems to happen once every few dozen attempts, so I can not rule out that the changes lead to undesired behavior in one of the other selection modes. I couldn't spot anything problematic from a cursory glance though.