### PR TITLE
mac: close app with cmd+q

### DIFF
--- a/src/dune3d_application.cpp
+++ b/src/dune3d_application.cpp
@@ -90,7 +90,11 @@ void Dune3DApplication::on_startup()
         }
     });
     add_action("logger", [this] { show_log_window(); });
-    // add_action("quit", sigc::mem_fun(*this, &PoolProjectManagerApplication::on_action_quit));
+    add_action("quit", [this] {
+        for (auto &win : get_windows()) {
+            win->close();
+        }
+    });
     // add_action("new_window", sigc::mem_fun(*this, &PoolProjectManagerApplication::on_action_new_window));
     add_action("about", sigc::mem_fun(*this, &Dune3DApplication::on_action_about));
     // add_action("view_log", [this] { show_log_window(); });


### PR DESCRIPTION
### Scope

- Bind built-in `quit` action to send a close request to all open windows, ensuring that unsaved changes will prevent the app from exiting
- Cmd+Q accelerator will be assigned automatically, no manual setup necessary

### Out of scope

- This will only enable the `Quit Dune 3D` menu item. There are still a number of other default menu items that are disabled, most notably the entire `Edit` menu (Undo/Redo, Cut/Copy/Paste/Delete/Select-All) - enabling them requires binding more of the magic built-in action names.
- Only tested on macOS, I have no idea whether the built-in `quit` action is triggered on other platforms as well. if in doubt, I can just wrap it in an `#ifdef`.