### PR TITLE
fix minor layout issue on welcome screen

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -291,6 +291,7 @@ welcome-box</property>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="halign">start</property>
+                                        <property name="hexpand">True</property>
                                         <property name="justify">fill</property>
                                         <property name="label">Press space anywhere in the 3D viewport to open the searchable global menu.</property>
                                         <property name="max-width-chars">0</property>


### PR DESCRIPTION
This one has been annoying me more than I'd like to admit.

Before:

<img width="1136" alt="Screenshot 2025-04-09 at 01 24 29" src="https://github.com/user-attachments/assets/16c710d4-7a5f-4d34-b779-40020b980395" />

After:

<img width="1136" alt="Screenshot 2025-04-09 at 01 24 52" src="https://github.com/user-attachments/assets/c2fb6e63-d49d-4af8-8ff0-d0efd513ad32" />
