### PR TITLE
remove extraneous file extension when saving

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -243,6 +243,11 @@ std::string Core::DocumentInfo::get_basename() const
     return path_to_string(m_path.filename());
 }
 
+std::string Core::DocumentInfo::get_stem() const
+{
+    return path_to_string(m_path.stem());
+}
+
 std::string Core::DocumentInfo::get_name() const
 {
     auto bn = get_basename();

--- a/src/core/core.hpp
+++ b/src/core/core.hpp
@@ -191,6 +191,7 @@ private:
 
         const Document &get_last_document() const;
         std::string get_basename() const override;
+        std::string get_stem() const override;
         std::string get_name() const override;
         std::filesystem::path get_dirname() const override;
         std::filesystem::path get_path() const override;

--- a/src/core/idocument_info.hpp
+++ b/src/core/idocument_info.hpp
@@ -11,6 +11,7 @@ public:
     virtual Document &get_document() = 0;
     virtual const Document &get_document() const = 0;
     virtual std::string get_basename() const = 0;
+    virtual std::string get_stem() const = 0;
     virtual std::string get_name() const = 0;
     virtual std::filesystem::path get_dirname() const = 0;
     virtual std::filesystem::path get_path() const = 0;

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -868,9 +868,10 @@ void Editor::on_open_document(const ActionConnection &conn)
 void Editor::on_save_as(const ActionConnection &conn)
 {
     auto dialog = Gtk::FileDialog::create();
-    if (m_core.get_current_idocument_info().has_path()) {
-        dialog->set_initial_file(
-                Gio::File::create_for_path(path_to_string(m_core.get_current_idocument_info().get_path())));
+    auto &idoc = m_core.get_current_idocument_info();
+    if (idoc.has_path()) {
+        dialog->set_initial_folder(Gio::File::create_for_path(path_to_string(idoc.get_dirname())));
+        dialog->set_initial_name(idoc.get_stem());
     }
 
     // Add filters, so that only certain file types can be selected:

--- a/src/editor/editor_export.cpp
+++ b/src/editor/editor_export.cpp
@@ -28,17 +28,18 @@ get_export_initial_filename(const Dune3DApplication::UserConfig &cfg, const IDoc
         if (cfg.export_paths.contains(k))
             filename = cfg.export_paths.at(k).*export_type;
 
-        if (it->m_uuid == current_group && filename.size())
+        if (it->m_uuid == current_group && filename.size()) {
+            if (filename.ends_with(suffix))
+                filename = filename.substr(0, filename.size() - suffix.length());
             break;
+        }
     }
     if (!filename.size()) {
         static const char *d3ddoc_suffix = ".d3ddoc";
         // fallback to document
         auto doc_fn = path_to_string(doc_info.get_path());
-        if (doc_fn.size() && doc_fn.ends_with(d3ddoc_suffix)) {
-            auto wsn = doc_fn.substr(0, doc_fn.size() - strlen(d3ddoc_suffix));
-            filename = wsn + suffix;
-        }
+        if (doc_fn.size() && doc_fn.ends_with(d3ddoc_suffix))
+            filename = doc_fn.substr(0, doc_fn.size() - strlen(d3ddoc_suffix));
     }
 
     if (filename.size())


### PR DESCRIPTION
Fixes #186. I have tested this on macOS, but not on other platforms. I believe that this change should not cause any issues, due to `append_suffix_if_required` being called later on in the code path.