### PR TITLE
workaround macOS AMD GPU driver bug

### DIFF
--- a/src/canvas/shaders/face-vertex.glsl
+++ b/src/canvas/shaders/face-vertex.glsl
@@ -22,7 +22,7 @@ void main()
 {
     // gl_Position = proj*view*vec4(position, 1, 1);
     color_to_fragment = color;
-    if(!isnan(override_color.r))
+    if(override_color.r == override_color.r)  // isnan() is broken on some platforms
         color_to_fragment = override_color;
     vec4 p4 = vec4(position*normal_mat + origin, 1);
     vec4 n4 = vec4(normal, 0);

--- a/src/canvas/shaders/icon-vertex.glsl
+++ b/src/canvas/shaders/icon-vertex.glsl
@@ -25,7 +25,7 @@ void main() {
 	flags_to_geom = flags;
     origin_to_geom = (proj*view*vec4(origin, 1));
     vec3 t = screen*vec3(1,-1,0);
-    if(!isnan(vec.x)) {
+    if(vec.x == vec.x) {  // isnan() is broken on some platforms
         vec4 v4 = proj*view*vec4(vec, 0);
         v4.y *= -1;
         vec_to_geom = normalize(v4.xy/t.xy);


### PR DESCRIPTION
For some reason, `isnan()` was always returning false, even when being passed a NaN. Given that `isnan(x)` is essentially equivalent to testing if `x != x` (additionally suppressing exceptions from signalling NaNs, which we shouldn't run into here), the latter can just be substituted in instead.

Fixes #184.