### PR TITLE
increase default workplane size to 100x100mm

### DIFF
--- a/src/canvas/canvas.hpp
+++ b/src/canvas/canvas.hpp
@@ -318,7 +318,7 @@ private:
     bool m_needs_resize = false;
 
     glm::quat m_cam_quat;
-    float m_cam_distance = 10;
+    float m_cam_distance = 100;
     float m_cam_fov = 45;
     glm::vec3 m_center = {0, 0, 0};
     Projection m_projection = Projection::ORTHO;

--- a/src/document/entity/entity_workplane.cpp
+++ b/src/document/entity/entity_workplane.cpp
@@ -5,7 +5,8 @@
 
 namespace dune3d {
 EntityWorkplane::EntityWorkplane(const UUID &uu)
-    : Base(uu), m_normal(glm::quat_identity<double, glm::defaultp>()), m_size(10, 10)
+    : Base(uu), m_normal(glm::quat_identity<double, glm::defaultp>()),
+      m_size(EntityWorkplane::s_default_size, EntityWorkplane::s_default_size)
 {
 }
 

--- a/src/document/entity/entity_workplane.hpp
+++ b/src/document/entity/entity_workplane.hpp
@@ -10,6 +10,7 @@ public:
     explicit EntityWorkplane(const UUID &uu);
     explicit EntityWorkplane(const UUID &uu, const json &j);
     static constexpr Type s_type = Type::WORKPLANE;
+    static constexpr double s_default_size = 100.0;
     json serialize() const override;
 
     virtual bool has_name() const override

--- a/src/document/group/group_reference.cpp
+++ b/src/document/group/group_reference.cpp
@@ -3,7 +3,6 @@
 #include "util/util.hpp"
 #include "util/glm_util.hpp"
 #include "document/document.hpp"
-#include "document/entity/entity_workplane.hpp"
 
 namespace dune3d {
 GroupReference::GroupReference(const UUID &uu) : Group(uu)
@@ -12,8 +11,10 @@ GroupReference::GroupReference(const UUID &uu) : Group(uu)
 
 GroupReference::GroupReference(const UUID &uu, const json &j)
     : Group(uu, j), m_show_xy(j.value("show_xy", true)), m_show_yz(j.value("show_yz", true)),
-      m_show_zx(j.value("show_zx", true)), m_xy_size(j.value("xy_size", glm::dvec2(10, 10))),
-      m_yz_size(j.value("yz_size", glm::dvec2(10, 10))), m_zx_size(j.value("zx_size", glm::dvec2(10, 10)))
+      m_show_zx(j.value("show_zx", true)),
+      m_xy_size(j.value("xy_size", glm::dvec2(EntityWorkplane::s_default_size, EntityWorkplane::s_default_size))),
+      m_yz_size(j.value("yz_size", glm::dvec2(EntityWorkplane::s_default_size, EntityWorkplane::s_default_size))),
+      m_zx_size(j.value("zx_size", glm::dvec2(EntityWorkplane::s_default_size, EntityWorkplane::s_default_size)))
 {
 }
 

--- a/src/document/group/group_reference.hpp
+++ b/src/document/group/group_reference.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "group.hpp"
 #include "igroup_generate.hpp"
+#include "document/entity/entity_workplane.hpp"
 #include <glm/gtx/quaternion.hpp>
 
 namespace dune3d {
@@ -25,9 +26,9 @@ public:
     bool m_show_yz = true;
     bool m_show_zx = true;
 
-    glm::dvec2 m_xy_size = {10, 10};
-    glm::dvec2 m_yz_size = {10, 10};
-    glm::dvec2 m_zx_size = {10, 10};
+    glm::dvec2 m_xy_size = {EntityWorkplane::s_default_size, EntityWorkplane::s_default_size};
+    glm::dvec2 m_yz_size = {EntityWorkplane::s_default_size, EntityWorkplane::s_default_size};
+    glm::dvec2 m_zx_size = {EntityWorkplane::s_default_size, EntityWorkplane::s_default_size};
 
     UUID get_workplane_xy_uuid() const;
     UUID get_workplane_yz_uuid() const;

--- a/src/workspace/workspace_view.hpp
+++ b/src/workspace/workspace_view.hpp
@@ -25,7 +25,7 @@ public:
     UUID m_current_document;
 
     glm::vec3 m_center = glm::vec3(0, 0, 0);
-    float m_cam_distance = 10;
+    float m_cam_distance = 100;
     CanvasProjection m_projection = CanvasProjection::ORTHO;
     glm::quat m_cam_quat = glm::quat_identity<float, glm::defaultp>();
     float m_curvature_comb_scale = 0;


### PR DESCRIPTION
### Rationale

By default, all workplanes are sized to 10x10mm which is tiny by any standard - the resulting work volume is three orders of magnitude smaller than the build volume of any entry-level 3D printer, for instance. I can't provide tangible data on determining the "right" value for the new defaults, but intuitively 100x100mm appears to be a reasonable size.

### Scope

- When creating a new document, change default XY/YZ/ZX workplane sizes to 100x100mm
- Set default size of newly created workplane entities to 100x100mm
- Adjust default zoom level to adapt for larger workplanes

### Out of scope

- With the new increased default size, the maximum workplane size is now only one order of magnitude away from the default. I'm wondering if the maximum size should be increased as well? Anecdotal data point: The 3D model of my CNC machine would already exceed a maximum 1000x1000 workplane size.