### PR TITLE
Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -134,11 +134,14 @@ jobs:
     needs: stylecheck
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: nixbuild/nix-quick-install-action@master
+    - uses: nix-community/cache-nix-action@main
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
     - name: Build
       run: nix build .
-  
+
   build-nix-macos:
     strategy:
       fail-fast: false
@@ -146,7 +149,10 @@ jobs:
     needs: stylecheck
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: nixbuild/nix-quick-install-action@master
+    - uses: nix-community/cache-nix-action@main
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
     - name: Build
       run: nix build .


### PR DESCRIPTION
The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works. This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `DeterminateSystems/nix-installer-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.