### PR TITLE
Made the datum constraints automatically open the datum dialog

### DIFF
--- a/src/core/core.hpp
+++ b/src/core/core.hpp
@@ -55,6 +55,11 @@ public:
     ToolResponse tool_begin(ToolID tool_id, const ToolArgs &args, bool transient = false);
     ToolResponse tool_update(ToolArgs &args);
 
+    void push_next_tool(ToolArgs &args)
+    {
+        this->m_pending_tool_args.emplace_back(std::move(args));
+    }
+
     std::set<InToolActionID> get_tool_actions() const;
 
     struct CanBeginInfo {

--- a/src/core/tool.hpp
+++ b/src/core/tool.hpp
@@ -6,6 +6,7 @@
 #include "bitmask_operators.hpp"
 #include <glm/glm.hpp>
 #include <set>
+#include <optional>
 
 namespace dune3d {
 
@@ -28,6 +29,7 @@ public:
     bool m_keep_selection = false;
     InToolActionID action;
     std::unique_ptr<ToolData> data = nullptr;
+    ToolID tool_id;
 
     /*Target target;
     int work_layer = 0;
@@ -42,7 +44,7 @@ class ToolResponse {
 public:
     // ToolID next_tool;
     //  std::unique_ptr<ToolData> data = nullptr;
-    enum class Result { NOP, END, COMMIT, REVERT };
+    enum class Result { NOP, END, COMMIT, REVERT, EDIT_DATUM };
     Result result = Result::NOP;
     /**
      * Use this if you're done. The Core will then delete the active tool and
@@ -66,15 +68,17 @@ public:
     /**
      * If you want another Tool to be launched you've finished, use this one.
      */
-    /*static ToolResponse next(Result res, ToolID t, std::unique_ptr<ToolData> data = nullptr)
+    static ToolResponse next(Result res, ToolID tool_id, ToolArgs tool_args)
     {
         ToolResponse r(res);
-        r.next_tool = t;
-        r.data = std::move(data);
+        r.next_tool_args = std::move(tool_args);
+        r.next_tool_args.value().tool_id = tool_id;
         return r;
-    };*/
+    };
 
     ToolResponse();
+
+    std::optional<ToolArgs> next_tool_args;
 
 private:
     ToolResponse(Result r);

--- a/src/core/tools/tool_common_constrain_datum.cpp
+++ b/src/core/tools/tool_common_constrain_datum.cpp
@@ -9,6 +9,7 @@
 #include "dialogs/dialogs.hpp"
 #include "dialogs/enter_datum_window.hpp"
 #include "tool_common_constrain_impl.hpp"
+#include "core/tool_id.hpp"
 
 namespace dune3d {
 
@@ -24,7 +25,13 @@ ToolResponse ToolCommonConstrainDatum::prepare_interactive(Constraint &constrain
     if (auto wrkpl_uu = co_wrkpl.get_workplane(get_doc()))
         m_constraint_wrkpl = &get_entity<EntityWorkplane>(wrkpl_uu);
 
-    return ToolResponse();
+    ToolArgs args;
+    SelectableRef ref;
+    ref.type = SelectableRef::Type::CONSTRAINT;
+    ref.item = constraint.m_uuid;
+    args.selection.insert(std::move(ref));
+
+    return ToolResponse::next(ToolResponse::Result::NOP, ToolID::ENTER_DATUM, std::move(args));
 }
 
 ToolResponse ToolCommonConstrainDatum::update(const ToolArgs &args)

--- a/src/editor/editor_tool.cpp
+++ b/src/editor/editor_tool.cpp
@@ -63,6 +63,11 @@ void Editor::tool_update_data(std::unique_ptr<ToolData> data)
 
 void Editor::tool_process(ToolResponse &resp)
 {
+    if (resp.next_tool_args.has_value()) {
+        auto next_tool_args = std::move(resp.next_tool_args.emplace());
+        m_core.push_next_tool(next_tool_args);
+    }
+
     tool_process_one();
     while (auto args = m_core.get_pending_tool_args()) {
         m_core.tool_update(*args);


### PR DESCRIPTION
Whenever I add a distance constraint I'd expect it to automatically open up the popup. Currently it requires me to select the constraint again. This PR automatically opens the datum dialog whenever you add a datum constraint.

My C++ is a bit rusty (pun intended) so please let me know if I can do things better.