### PR TITLE
mac: fix point and body color rendering on arm64

### DIFF
--- a/src/canvas/shaders/face-vertex.glsl
+++ b/src/canvas/shaders/face-vertex.glsl
@@ -22,7 +22,7 @@ void main()
 {
     // gl_Position = proj*view*vec4(position, 1, 1);
     color_to_fragment = color;
-    if(override_color.r == override_color.r)  // isnan() is broken on some platforms
+    if(override_color.r == override_color.r && !isnan(override_color.r))  // isnan() is broken on some platforms, but nan == nan evaluates to true on some others
         color_to_fragment = override_color;
     vec4 p4 = vec4(position*normal_mat + origin, 1);
     vec4 n4 = vec4(normal, 0);

--- a/src/canvas/shaders/icon-vertex.glsl
+++ b/src/canvas/shaders/icon-vertex.glsl
@@ -25,7 +25,7 @@ void main() {
 	flags_to_geom = flags;
     origin_to_geom = (proj*view*vec4(origin, 1));
     vec3 t = screen*vec3(1,-1,0);
-    if(vec.x == vec.x) {  // isnan() is broken on some platforms
+    if(vec.x == vec.x && !isnan(vec.x)) {  // isnan() is broken on some platforms, but nan == nan evaluates to true on some others
         vec4 v4 = proj*view*vec4(vec, 0);
         v4.y *= -1;
         vec_to_geom = normalize(v4.xy/t.xy);


### PR DESCRIPTION
Fixes #216.

This fix should work because either `nan == nan` or `!isnan(nan)` (or both) should evaluate to `false`, even if one of the implementations is broken.