### PR TITLE
UX/UI added double click on axeslollipop widget to snap view axis

### DIFF
--- a/src/dune3d_appwindow.cpp
+++ b/src/dune3d_appwindow.cpp
@@ -151,6 +151,7 @@ Dune3DAppWindow::Dune3DAppWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk
     {
         Gtk::Box *lollipop_box = refBuilder->get_widget<Gtk::Box>("lollipop_box");
         auto axes_lollipop = Gtk::make_managed<AxesLollipop>();
+        axes_lollipop->set_canvas(get_canvas()); // Add this line
         lollipop_box->append(*axes_lollipop);
         get_canvas().signal_view_changed().connect(sigc::track_obj(
                 [this, axes_lollipop] { axes_lollipop->set_quat(get_canvas().get_cam_quat()); }, *axes_lollipop));

--- a/src/widgets/axes_lollipop.cpp
+++ b/src/widgets/axes_lollipop.cpp
@@ -1,6 +1,9 @@
 #include "axes_lollipop.hpp"
+#include "canvas/canvas.hpp"
 #include "util/color.hpp"
 #include <glm/gtx/rotate_vector.hpp>
+#include <glm/gtc/quaternion.hpp>
+#include <iostream>
 
 namespace dune3d {
 
@@ -36,7 +39,16 @@ AxesLollipop::AxesLollipop()
     set_content_height(100);
     set_content_width(100);
     set_draw_func(sigc::mem_fun(*this, &AxesLollipop::render));
-    // signal_screen_changed().connect([this](const Glib::RefPtr<Gdk::Screen> &screen) { create_layout(); });
+    
+    // Make the widget focusable and clickable
+    set_can_focus(true);
+    set_focusable(true);
+    
+    // Add click event controller
+    auto click_controller = Gtk::GestureClick::create();
+    click_controller->set_button(1); // Left click
+    click_controller->signal_pressed().connect(sigc::mem_fun(*this, &AxesLollipop::on_click));
+    add_controller(click_controller);
 }
 
 void AxesLollipop::create_layout()
@@ -52,6 +64,98 @@ void AxesLollipop::set_quat(const glm::quat &q)
 {
     m_quat = q;
     queue_draw();
+}
+
+void AxesLollipop::set_canvas(Canvas &canvas)
+{
+    m_canvas = &canvas;
+}
+
+int AxesLollipop::get_clicked_axis(double x, double y, int w, int h) const
+{
+    const float sc = (std::min(w, h) / 2) - m_size;
+    const float center_x = w / 2.0f;
+    const float center_y = h / 2.0f;
+    
+    // Transform screen coordinates to widget coordinates
+    const float widget_x = x - center_x;
+    const float widget_y = center_y - y; // Invert Y axis
+    
+    std::vector<std::pair<unsigned int, glm::vec3>> pts;
+    for (unsigned int ax = 0; ax < 3; ax++) {
+        const glm::vec3 v(ax == 0, ax == 1, ax == 2);
+        const auto vt = glm::rotate(glm::inverse(m_quat), v) * sc;
+        pts.emplace_back(ax, vt);
+    }
+    
+    // Find the closest axis endpoint to the click position
+    float min_distance = std::numeric_limits<float>::max();
+    int closest_axis = -1;
+    
+    for (const auto &[ax, vt] : pts) {
+        const float dx = widget_x - vt.x;
+        const float dy = widget_y - vt.y;
+        const float distance = std::sqrt(dx*dx + dy*dy);
+        
+        // Check if click is within a reasonable distance of the axis endpoint
+        if (distance < m_size && distance < min_distance) {
+            min_distance = distance;
+            closest_axis = ax;
+        }
+    }
+    
+    return closest_axis;
+}
+
+void AxesLollipop::on_click(guint n_press, double x, double y)
+{
+    if (n_press == 2 && m_canvas) { // Double click
+        int w = get_width();
+        int h = get_height();
+        
+        int clicked_axis = get_clicked_axis(x, y, w, h);
+        
+        if (clicked_axis >= 0) {
+            switch (clicked_axis) {
+                case 0: // X axis - snap to YZ plane
+                    snap_to_yz_plane();
+                    break;
+                case 1: // Y axis - snap to XZ plane
+                    snap_to_xz_plane();
+                    break;
+                case 2: // Z axis - snap to XY plane
+                    snap_to_xy_plane();
+                    break;
+            }
+        }
+    }
+}
+
+void AxesLollipop::snap_to_xy_plane()
+{
+    if (m_canvas) {
+        // Snap to XY plane (looking down Z axis)
+        glm::quat q = glm::angleAxis(0.0f, glm::vec3(1, 0, 0));
+        m_canvas->animate_to_cam_quat(q);
+    }
+}
+
+void AxesLollipop::snap_to_xz_plane()
+{
+    if (m_canvas) {
+        // Snap to XZ plane (looking down Y axis)
+        glm::quat q = glm::angleAxis(glm::radians(-90.0f), glm::vec3(1, 0, 0));
+        m_canvas->animate_to_cam_quat(q);
+    }
+}
+
+void AxesLollipop::snap_to_yz_plane()
+{
+    if (m_canvas) {
+        // Snap to YZ plane (looking down X axis)
+        glm::quat q = glm::angleAxis(glm::radians(-90.0f), glm::vec3(0, 1, 0));
+        m_canvas->animate_to_cam_quat(q);
+    }
 }
 
 void AxesLollipop::render(const Cairo::RefPtr<Cairo::Context> &cr, int w, int h)

--- a/src/widgets/axes_lollipop.hpp
+++ b/src/widgets/axes_lollipop.hpp
@@ -3,17 +3,37 @@
 #include <glm/gtx/quaternion.hpp>
 
 namespace dune3d {
+
+class Canvas;
+
 class AxesLollipop : public Gtk::DrawingArea {
 public:
     AxesLollipop();
     void set_quat(const glm::quat &q);
+    
+    // Add method to set the canvas for view manipulation
+    void set_canvas(Canvas &canvas);
 
 private:
     glm::quat m_quat;
     Glib::RefPtr<Pango::Layout> m_layout;
     float m_size = 5;
+    
+    // Add canvas pointer for view manipulation
+    Canvas *m_canvas = nullptr;
+    
+    // Add methods for snapping to planes
+    void snap_to_xy_plane();
+    void snap_to_xz_plane();
+    void snap_to_yz_plane();
+    
+    // Add method to determine which axis was clicked
+    int get_clicked_axis(double x, double y, int w, int h) const;
 
     void render(const Cairo::RefPtr<Cairo::Context> &cr, int w, int h);
     void create_layout();
+    
+    // Add event handling
+    void on_click(guint n_press, double x, double y);
 };
 } // namespace dune3d

--- a/src/window.ui
+++ b/src/window.ui
@@ -401,7 +401,7 @@ blah</property>
                     </child>
                     <child type="overlay">
                       <object class="GtkBox" id="lollipop_box">
-                        <property name="can-target">False</property>
+                        <property name="can-target">True</property>
                         <property name="halign">end</property>
                         <property name="margin-end">10</property>
                         <property name="margin-top">10</property>


### PR DESCRIPTION
This pull request introduces enhancements to the `AxesLollipop` widget, enabling it to interact with the canvas and handle user input for snapping the view to YZ,XZ,XY (x,y,z)  planes. 
![Screencast_20250804_190106](https://github.com/user-attachments/assets/227c5e3b-6498-46a2-a551-f506a6303c1e)
The changes improve the user experience by adding interactivity and functionality to the widget. Below are the most important changes grouped by their themes:


### Enhancements to `AxesLollipop` functionality:
* Added a `set_canvas` method to the `AxesLollipop` class to associate the widget with the canvas, allowing it to manipulate the view. (`src/widgets/axes_lollipop.cpp`, `src/widgets/axes_lollipop.hpp`) [[1]](diffhunk://#diff-eecda4f4ab3e82f2ab50640a2033e1f5f76713c45edaa70f5747caf6810b3494R69-R160) [[2]](diffhunk://#diff-a8d8f49c989222c3d19f32d088ab6579cc2dc3d777c54c76360d34e71f1a9e91R6-R37)
* Implemented snapping methods (`snap_to_xy_plane`, `snap_to_xz_plane`, `snap_to_yz_plane`) to adjust the camera view to align with specific planes (XY, XZ, YZ) based on user interaction. (`src/widgets/axes_lollipop.cpp`, `src/widgets/axes_lollipop.hpp`) [[1]](diffhunk://#diff-eecda4f4ab3e82f2ab50640a2033e1f5f76713c45edaa70f5747caf6810b3494R69-R160) [[2]](diffhunk://#diff-a8d8f49c989222c3d19f32d088ab6579cc2dc3d777c54c76360d34e71f1a9e91R6-R37)
* Added a `get_clicked_axis` method to determine which axis was clicked by the user, enabling precise snapping functionality. (`src/widgets/axes_lollipop.cpp`, `src/widgets/axes_lollipop.hpp`) [[1]](diffhunk://#diff-eecda4f4ab3e82f2ab50640a2033e1f5f76713c45edaa70f5747caf6810b3494R69-R160) [[2]](diffhunk://#diff-a8d8f49c989222c3d19f32d088ab6579cc2dc3d777c54c76360d34e71f1a9e91R6-R37)

### User interaction improvements:
* Made the `AxesLollipop` widget focusable and clickable, and added a click event controller to handle user input, including double-clicks for snapping the view. (`src/widgets/axes_lollipop.cpp`)
* Updated the `lollipop_box` in the UI file to make it targetable, ensuring the widget can receive user interactions. (`src/window.ui`)

### Integration with the canvas:
* Linked the `AxesLollipop` widget to the canvas by setting the canvas instance during initialization in `Dune3DAppWindow`. (`src/dune3d_appwindow.cpp`)
* Included necessary headers for canvas and quaternion operations to support the new functionality. (`src/widgets/axes_lollipop.cpp`)