### PR TITLE
Add angle spinner to Revolve group editor

### DIFF
--- a/src/editor/group_editor/group_editor_revolve.cpp
+++ b/src/editor/group_editor/group_editor_revolve.cpp
@@ -9,6 +9,13 @@ GroupEditorRevolve::GroupEditorRevolve(Core &core, const UUID &group_uu) : Group
 {
     auto &group = get_group();
     add_operation_combo();
+
+    m_angle_sp = Gtk::make_managed<SpinButtonAngle>();
+    m_angle_sp->set_hexpand(true);
+    m_angle_sp->set_value(group.m_angle < 0 ? group.m_angle + 360 : group.m_angle);
+    connect_spinbutton(*m_angle_sp, sigc::mem_fun(*this, &GroupEditorRevolve::update_angle));
+    grid_attach_label_and_widget(*this, "Angle", *m_angle_sp, m_top);
+
     {
         auto items = Gtk::StringList::create();
         items->append("Single");
@@ -33,7 +40,19 @@ void GroupEditorRevolve::do_reload()
 {
     GroupEditorSweep::do_reload();
     auto &group = get_group();
+    m_angle_sp->set_value(group.m_angle < 0 ? group.m_angle + 360 : group.m_angle);
     m_mode_combo->set_selected(static_cast<guint>(group.m_mode));
+}
+
+bool GroupEditorRevolve::update_angle()
+{
+    if (is_reloading())
+        return false;
+    if (get_group().m_angle == m_angle_sp->get_value())
+        return false;
+    get_group().m_angle = m_angle_sp->get_value();
+    m_core.get_current_document().set_group_generate_pending(get_group().m_uuid);
+    return true;
 }
 
 GroupRevolve &GroupEditorRevolve::get_group()

--- a/src/editor/group_editor/group_editor_revolve.hpp
+++ b/src/editor/group_editor/group_editor_revolve.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "group_editor_sweep.hpp"
+#include "widgets/spin_button_angle.hpp"
 
 namespace dune3d {
 
@@ -12,7 +13,9 @@ public:
 
 private:
     GroupRevolve &get_group();
+    bool update_angle();
 
+    SpinButtonAngle *m_angle_sp = nullptr;
     Gtk::DropDown *m_mode_combo = nullptr;
 };
 } // namespace dune3d


### PR DESCRIPTION
## Summary
Adds an editable angle control to the Revolve group properties panel so users can change the revolve angle without editing the document file, making it faster to get the result you want.

<img width="1013" height="743" alt="Screenshot 2026-03-13 at 11 46 06 AM" src="https://github.com/user-attachments/assets/619c2416-2eb0-4b00-8de5-369fbe59d217" />

## Changes
- Added `SpinButtonAngle` to `GroupEditorRevolve` for editing `m_angle`
- Angle is displayed between Operation/Source group and Mode
- Normalizes negative angles to 0-360 for display (equivalent rotations)

## Testing
- [x] Create revolve group, change angle via spinner
- [x] Verify 3D view updates
- [x] Save/reload document preserves angle
- [x] Negative angles from solver normalize correctly