### PR TITLE
rework macos workflow to produce installable dmg

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -54,23 +54,23 @@ jobs:
     - name: Build
       run: bash scripts/build_macos.sh && otool -L build/dune3d
     - name: Install dependencies for bundling
-      run: brew install dylibbundler
+      run: brew install dylibbundler create-dmg
     - name: Set artifact name
       run: echo "artifact_name=dune3d-${{ matrix.arch }}-$(date +%Y-%m-%d-%H%M)-$(echo ${{ github.ref_name }} | tr / -)" >> $GITHUB_ENV
     - name: Bundle app
       timeout-minutes: 10
       run: |
         bash scripts/bundle_macos.sh
-        brew install create-dmg
         create-dmg \
           --volname "Dune3D" \
-          --window-size 500 300 \
+          --window-size 800 400 \
           --icon-size 100 \
           --app-drop-link 400 150 \
           "dist/Dune3D-${{ matrix.arch }}.dmg" \
           "dist/Dune 3D.app"
     - name: Upload bundle
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.artifact_name }}
         path: "dist/Dune3D-${{ matrix.arch }}.dmg"
+        archive: false

--- a/scripts/bundle_macos.sh
+++ b/scripts/bundle_macos.sh
@@ -32,10 +32,8 @@ do
   then
     cp "$unquoted" "$loaders_dir"
     echo "\"@executable_path/../Resources/lib/gdk-pixbuf-2.0/2.10.0/loaders/$(basename "$unquoted")\"" >> "$loaders_dir.cache"
-    dylibbundler -of -b -x "$loaders_dir/$(basename "$unquoted")" -d "$lib_dir" -p @executable_path/../Resources/lib/ -s $brew_prefix/lib
   else
     echo "$item" >> "$loaders_dir.cache"
   fi
 done
-dylibbundler -of -b -x  "$bin_dir/dune3d-bin" -d "$lib_dir" -p @executable_path/../Resources/lib/
 codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - "$app_dir"


### PR DESCRIPTION
I've replaced the .zip archivation of the produced Dune 3D.app to a .dmg file creation which is a more convenient way to distribute.