### PR TITLE
Hide window close button if inactive

### DIFF
--- a/src/dune3d_appwindow.cpp
+++ b/src/dune3d_appwindow.cpp
@@ -497,6 +497,11 @@ void Dune3DAppWindow::WorkspaceTabLabel::set_label(const std::string &label)
 
 void Dune3DAppWindow::WorkspaceTabLabel::set_can_close(bool can_close)
 {
+    if (can_close)
+        m_close_button->show();
+    else
+        m_close_button->hide();
+
     m_close_button->set_sensitive(can_close);
     m_can_close = can_close;
     m_close_action->set_enabled(can_close);

--- a/src/dune3d_appwindow.cpp
+++ b/src/dune3d_appwindow.cpp
@@ -502,7 +502,6 @@ void Dune3DAppWindow::WorkspaceTabLabel::set_can_close(bool can_close)
     else
         m_close_button->hide();
 
-    m_close_button->set_sensitive(can_close);
     m_can_close = can_close;
     m_close_action->set_enabled(can_close);
 }


### PR DESCRIPTION
Most of the time this button is inactive. Therefore hide it if inactive to not confuse users.