### PR TITLE
mac: strip LC_RPATHs when creating app bundle

### DIFF
--- a/scripts/bundle_macos.sh
+++ b/scripts/bundle_macos.sh
@@ -9,7 +9,9 @@ lib_dir="$res_dir/lib"
 brew_prefix="$(brew --prefix)"
 
 mkdir -p "$bin_dir" "$lib_dir" "$res_dir/share/icons" "$res_dir/share/glib-2.0"
-cp build/dune3d "$bin_dir/dune3d-bin"
+# Using meson install omits LC_RPATHs in the main executable.
+meson install -C build --destdir stage --tags runtime
+find build/stage -name dune3d -type f -exec cp -v '{}' "$bin_dir/dune3d-bin" \;
 cp Info.plist "$app_dir/Contents"
 cp macos-launcher.sh "$bin_dir/dune3d"
 chmod +x "$bin_dir/dune3d"
@@ -38,4 +40,33 @@ do
   fi
 done
 dylibbundler -of -b -x  "$bin_dir/dune3d-bin" -d "$lib_dir" -p @executable_path/../Resources/lib/
+
+# dylibbundler rewrote all load commands to @executable_path but also updated
+# the LC_RPATH entries to @executable_path/../Resources/lib/. Since the LC_RPATH
+# entries are redundant and duplicates prevent the app from launching when
+# linked against the macOS 26 SDK, we strip them out entirely.
+strip_rpaths() {
+  if otool -L "$1" | grep '@rpath/' >/dev/null
+  then
+    echo "FATAL: @rpath found in $1" >&2
+    exit 1
+  fi
+  rpaths=$(otool -l "$1" | awk '$2 == "LC_RPATH" {rp=1}
+    rp && $1 == "path" {sub(/^ *path /, ""); sub(/ \(offset [0-9]+\)$/, ""); print; rp=0}')
+  if [[ -n "$rpaths" ]]
+  then
+    echo "* Stripping LC_RPATHs from $1"
+    while IFS= read -r rp
+    do
+      install_name_tool -delete_rpath "$rp" "$1"
+    done <<< "$rpaths"
+    codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - "$1"
+  fi
+}
+
+while IFS= read -r item
+do
+  strip_rpaths "$item"
+done < <(find "$app_dir" -type f \( -name '*.dylib' -o -name '*.so' \))
+
 codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - "$app_dir"


### PR DESCRIPTION
The app bundle created by bundle_macos.sh contained duplicate LC_RPATH entries. This was preventing it from launching when built and run under macOS 26, whose dyld rejects duplicate LC_RPATH entries in binaries linked against macOS SDK >= 26:

    $ ./dist/Dune\ 3D.app/Contents/MacOS/dune3d
    dyld[81678]: duplicate LC_RPATH '@executable_path/../Resources/lib/'
                 in dune3d/dist/Dune 3D.app/Contents/MacOS/dune3d-bin
    ./dist/Dune 3D.app/Contents/MacOS/dune3d: line 27: 81678 Abort trap: 6

The duplicate LC_RPATH entries arise from dylibbundler updating every LC_RPATH entry it encounters to the exact same @executable_path directory (i.e. the directory we pass it via its `-p` option).

Because dylibbundler also changes all load commands to be @executable_path relative, there's no reason to retain LC_RPATHs, which are only used with @rpath-relative load commands. So this commit omits them with two changes:

First, the bundling script now uses meson install to stage the dune3d binary before copying it into the app bundle. The meson install command omits LC_RPATHs. Second, the script takes a pass over the bundled libraries and removes any LC_RPATHs it finds. This second pass is needed due to homebrew-provided libraries using LC_RPATHs.